### PR TITLE
#98400 Make the module compatible with PHP 8.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 #Changelog
 
 ## [Unreleased]
+- Make the module compatible with PHP 8.2
 
 ## 1.0.3
 - Make the module compatible with PHP 8.1

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "magento/module-wishlist": "*",
         "magento/magento-composer-installer": "*",
-        "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.1.0"
+        "php": "~7.0.0|~7.1.0|~7.2.0|~7.3.0|~7.4.0|~8.1.0|~8.2.0"
     },
     "type": "magento2-module",
     "autoload": {


### PR DESCRIPTION
Tested on a local 2.4.6 Magento & PHP8.2 environment.
As far as I can tell, the module works properly.
Used `bin/magento config:set wishlist/general/items_limit 4` to change the default limit and `My Wish List` block shows now 4 items instead of 3. 

```js
require('Magento_Customer/js/customer-data').get(['wishlist'])(); 
```
Reloading customer-data.wishlist also returns proper data.